### PR TITLE
Search to add exercise

### DIFF
--- a/src/components/exercise-form.tsx
+++ b/src/components/exercise-form.tsx
@@ -22,11 +22,11 @@ const ExerciseForm = ({
   const nameInput = useRef<HTMLInputElement | null>(null)
 
   useEffect(() => {
-    if (nameInput.current) nameInput.current.focus()
+    if (nameInput.current && !initialName) nameInput.current.focus()
   }, [])
 
   return (
-    <div className="border border-border shadow shadow-shadow rounded-md p-4 flex flex-col space-y-4">
+    <form className="border border-border shadow shadow-shadow rounded-md p-4 flex flex-col space-y-4">
       <TextInput
         ref={nameInput}
         value={name}
@@ -39,6 +39,7 @@ const ExerciseForm = ({
         changeHandler={setNotes}
         label="Exercise notes"
         htmlFor="exerciseNotes"
+        autoFocus={!!initialName}
       />
       <div className="flex flex-row space-x-4">
         <Button onClick={() => onSubmit({ name, notes })}>
@@ -46,7 +47,7 @@ const ExerciseForm = ({
         </Button>
         <Button onClick={closeForm}>Cancel</Button>
       </div>
-    </div>
+    </form>
   )
 }
 

--- a/src/components/search-input.tsx
+++ b/src/components/search-input.tsx
@@ -1,0 +1,28 @@
+import React from "react"
+
+export default function ({
+  defaultValue = "",
+  inputCallback,
+}: {
+  defaultValue?: string
+  inputCallback: (value: string) => void
+}) {
+  const [value, setValue] = React.useState(defaultValue)
+
+  const onInput = (e: React.FormEvent<HTMLInputElement>) => {
+    const { value } = e.currentTarget
+    setValue(value)
+    inputCallback(value)
+  }
+
+  return (
+    <div className="flex flex-col">
+      <input
+        value={value}
+        placeholder={"Search or add exercises"}
+        onInput={onInput}
+        className="bg-background border border-border rounded-md shadow-sm shadow-shadow sm:px-3.5 sm:py-2 px-3 py-1.5 text-sm sm:text-base outline-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-900 focus-visible:border-transparent duration-[50ms]"
+      />
+    </div>
+  )
+}

--- a/src/components/textarea-input.tsx
+++ b/src/components/textarea-input.tsx
@@ -7,16 +7,19 @@ const TextareaInput = ({
   htmlFor,
   value,
   changeHandler,
+  autoFocus = false,
 }: {
   label: string
   htmlFor: string
   value: string
   changeHandler: (_: string) => void
+  autoFocus?: boolean
 }) => {
   return (
     <div className="flex flex-col">
       <Label htmlFor={htmlFor}>{label}</Label>
       <textarea
+        autoFocus={autoFocus}
         id={htmlFor}
         value={value}
         onChange={throughEvent(changeHandler)}


### PR DESCRIPTION
This PR adds a search bar to the exercises page to filter exercises for name matches in the substring. It also prepopulates the exercise name field if you click the "Add" button with text in the search bar.

Initial view
<img width="612" alt="image" src="https://user-images.githubusercontent.com/39470469/215997954-78f02a1e-5e90-4441-a363-99beb21ebf0e.png">
Type "pull"
<img width="626" alt="image" src="https://user-images.githubusercontent.com/39470469/215998058-05b039e4-9848-4249-9428-07e0a86aa831.png">
Click "Add pull"
<img width="595" alt="image" src="https://user-images.githubusercontent.com/39470469/215998248-ac181c52-409b-46de-a906-ecab403262a5.png">
Click "Add exercise"
<img width="614" alt="image" src="https://user-images.githubusercontent.com/39470469/215998312-f4523771-672c-422d-a93c-c18d13314149.png">

Due to the search filter feature, reordering may no longer be necessary. I suppose it could be removed to simplify things, but perhaps it still serves a purpose.