### PR TITLE
Set PWA start_url to the exercises route

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -21,7 +21,7 @@
   ],
   "theme_color": "#18181b",
   "background_color": "#18181b",
-  "start_url": "/light-weight/",
+  "start_url": "/light-weight/?#/exercises",
   "display": "standalone",
   "orientation": "portrait"
 }


### PR DESCRIPTION
This PR changes the PWA `start_url` to the **exercises** route. While the app only has one startup flow, reducing the number of clicks required by one makes sense.